### PR TITLE
g:fuzzy_roots

### DIFF
--- a/vim/plugin/fuzzyfinder_textmate.vim
+++ b/vim/plugin/fuzzyfinder_textmate.vim
@@ -82,7 +82,7 @@ RUBY
   " Configuration option: g:fuzzy_roots
   " Specifies roots in which the FuzzyFinder will search.
   if !exists('g:fuzzy_roots')
-    let g:fuzzy_roots = ['.']
+    let g:fuzzy_roots = '.'
   endif
 
   " Configuration option: g:fuzzy_ceiling


### PR DESCRIPTION
Hi.

I checked out you vim_dotfiles onto my NEW MACBOOK AIR! and found that when trying to \ff I was getting a ruby error around calling Array#split. Looks like g:fuzzy_roots needed to be a string instead of an array.

That's all.

-tk
