### PR TITLE
fix pathogen loading in sudosh environments

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -1,6 +1,10 @@
 set nocompatible
 syntax on
 
+if &shell == "/usr/bin/sudosh"
+  set shell=/bin/bash
+endif
+
 filetype off
 call pathogen#runtime_append_all_bundles()
 filetype plugin indent on
@@ -145,7 +149,3 @@ function! Trim()
 endfunction
 command! -nargs=0 Trim :call Trim()
 nnoremap <silent> <Leader>cw :Trim<CR>
-
-if &shell == "/usr/bin/sudosh"
-  set shell=/bin/bash
-endif


### PR DESCRIPTION
just move the shell fix that was in the bottom above the pathogen load line, and everything starts working.

bim bam boom. :smoking: :bomb: :fire:
