### PR TITLE
.vim and .gvim existing as dirs previously cause script to not run

### DIFF
--- a/activate.rb
+++ b/activate.rb
@@ -10,7 +10,7 @@ dot_files.each do |filename|
 
   sym_link = File.join(home_dir,".#{File.basename(filename)}")
 
-  FileUtils.rm sym_link if File.symlink?(sym_link) || File.exist?(sym_link)
+  File.directory?(sym_link) ? FileUtils.rm_rf(sym_link) : (FileUtils.rm sym_link if File.symlink?(sym_link) || File.exist?(sym_link))
   FileUtils.ln_s filename,sym_link
 end
 


### PR DESCRIPTION
.vim and .gvim are common directories that most people have prior to using this script; and you can't rm a dir, so it needs to be handled differently.  This change resolves the issue.
